### PR TITLE
Significantly simplify AFCStream constructor

### DIFF
--- a/src/MobileDeviceSharp.AFC/Native/AfcFileMode.cs
+++ b/src/MobileDeviceSharp.AFC/Native/AfcFileMode.cs
@@ -5,19 +5,39 @@
     /// </summary>
     internal enum AFCFileMode : int
     {
-
+        /// <summary>
+        /// Read only.
+        /// O_RDONLY. (r)
+        /// </summary>
         FopenRdonly = 1,
 
+        /// <summary>
+        /// Read and write.
+        /// O_RDWR | O_CREAT. (r+)
+        /// </summary>
         FopenRw = 2,
 
+        /// <summary>
+        /// Write only, file is created or truncated.
+        /// O_WRONLY | O_CREAT | O_TRUNC. (w)
+        /// </summary>
         FopenWronly = 3,
 
+        /// <summary>
+        /// Read and write, file is created or truncated.
+        /// O_RDWR | O_CREAT | O_TRUNC. (w+)
+        /// </summary>
         FopenWr = 4,
 
+        /// <summary>
+        /// Write only, file is created or opened in append mode.
+        /// O_WRONLY | O_APPEND | O_CREAT. (a)
+        /// </summary>
         FopenAppend = 5,
 
         /// <summary>
-        /// a+  O_RDWR   | O_APPEND | O_CREAT
+        /// Read and write, file is created or opened in append mode.
+        /// O_RDWR | O_APPEND | O_CREAT. (a+)
         /// </summary>
         FopenRdappend = 6,
     }


### PR DESCRIPTION
We simplify the AFCStream constructor by only support [FileAccess](https://learn.microsoft.com/dotnet/api/system.io.fileaccess
) and [FileMode](https://learn.microsoft.com/dotnet/api/system.io.filemode) natively supported by [afc_file_open](https://docs.libimobiledevice.org/libimobiledevice/latest/afc_8h_a2dbfca1d64e26daf9691ba2ddabc92ba.html#a2dbfca1d64e26daf9691ba2ddabc92ba). So now we only support  [FileMode](https://learn.microsoft.com/dotnet/api/system.io.filemode) and [FileAccess](https://learn.microsoft.com/dotnet/api/system.io.fileaccess
) when it directly corresponds to one value of [afc_file_mode](https://docs.libimobiledevice.org/libimobiledevice/latest/afc_8h_af7a2fa8f957bce530bd7b3aa8c3c3bf3.html#af7a2fa8f957bce530bd7b3aa8c3c3bf3) As a result now we cannot use `FileMode.Truncate` and `FileMode.CreateNew`. Also, we removed the FileAccess property because it is not present in FileStream.